### PR TITLE
Update the package to Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,11 @@ os:
   - osx
 
 julia:
-  - 0.4
-  - 0.5
   - 0.6
   - nightly
 
 matrix:
   allow_failures:
-    - julia: 0.6
     - julia: nightly
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | **Documentation**                                                               | **PackageEvaluator**                                                                            | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.4-img]][pkg-0.4-url] [![][pkg-0.5-img]][pkg-0.5-url] [![][pkg-0.6-img]][pkg-0.6-url] [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [[![][pkg-0.6-img]][pkg-0.6-url] [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
@@ -22,8 +22,7 @@ julia> Pkg.add("Highlights")
 
 ## Project Status
 
-The package is tested against Julia `0.4`, `0.5` on Linux, OS X, and Windows.
-It does not currently work on `0.6` or `0.7-dev` -- pull requests welcome.
+The package is tested against Julia `0.6` and `0.7-dev` on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 
@@ -55,10 +54,6 @@ then feel free to ask for help in the [Gitter chat room][gitter-url].
 
 [issues-url]: https://github.com/JuliaDocs/Highlights.jl/issues
 
-[pkg-0.4-img]: http://pkg.julialang.org/badges/Highlights_0.4.svg
-[pkg-0.4-url]: http://pkg.julialang.org/?pkg=Highlights&ver=0.4
-[pkg-0.5-img]: http://pkg.julialang.org/badges/Highlights_0.5.svg
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=Highlights&ver=0.5
 [pkg-0.6-img]: http://pkg.julialang.org/badges/Highlights_0.6.svg
 [pkg-0.6-url]: http://pkg.julialang.org/?pkg=Highlights&ver=0.6
 [pkg-0.7-img]: http://pkg.julialang.org/badges/Highlights_0.7.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
@@ -11,8 +7,6 @@ environment:
 
 matrix:
   allow_failures:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,7 +17,7 @@ regular expression lexing mechanism used by [Pygments](http://pygments.org/).
 Pkg.add("Highlights")
 ```
 
-The package has no dependencies other than Julia (`0.4` and up) itself.
+The package has no dependencies other than Julia (`0.6` and up) itself.
 
 ## Usage
 

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -5,20 +5,20 @@ using Compat
 import ..Highlights: Str, AbstractLexer
 import ..Highlights.Tokens: Tokens, TokenValue, ERROR
 
-type Mut{T}
+mutable struct Mut{T}
     value::T
 end
 
 Base.getindex(m::Mut) = m.value
 Base.setindex!(m::Mut, v) = m.value = v
 
-immutable Token
+struct Token
     value::TokenValue
     first::Int
     last::Int
 end
 
-immutable Context
+struct Context
     source::Str
     pos::Mut{Int}
     length::Int
@@ -30,7 +30,7 @@ end
 
 isdone(ctx::Context) = ctx.pos[] > ctx.length
 
-immutable State{s} end
+struct State{s} end
 
 const NULL_RANGE = 0:0
 valid(r::Range) = r !== NULL_RANGE
@@ -80,7 +80,7 @@ function error!(ctx::Context)
     return ctx
 end
 
-lex{T <: AbstractLexer}(s::AbstractString, l::Type{T}) = lex!(Context(s), l, State{:root}())
+lex(s::AbstractString, l::Type{T}) where {T <: AbstractLexer} = lex!(Context(s), l, State{:root}())
 
 function metadata end
 function lex! end
@@ -90,7 +90,7 @@ getdata(T) = getdata!(ObjectIdDict(), T)
 getdata!(d, ::Type{AbstractLexer}) = d
 getdata!(d, lxr) = (getdata!(d, supertype(lxr)); d[lxr] = metadata(lxr); d)
 
-immutable LexerData
+struct LexerData
     name::Str
     aliases::Vector{Str}
     filenames::Vector{Str}
@@ -187,7 +187,7 @@ prepare_bindings(other) = prepare_binding(other, :range)
 # A token such as `TEXT` or `NUMBER`.
 prepare_binding(t::TokenValue, range) = :($(Compiler).update!(ctx, $range, $t))
 # Call different lexer's `:root` state.
-prepare_binding{L}(::Type{L}, range) = :($(Compiler).update!(ctx, $range, $L, $(State{:root}())))
+prepare_binding(::Type{L}, range) where {L} = :($(Compiler).update!(ctx, $range, $L, $(State{:root}())))
 # Call current lexer in state `S`.
 prepare_binding(S::Symbol, range) = :($(Compiler).update!(ctx, $range, T, $(State{S}())))
 # Call different lexer's state `p.second`.

--- a/src/Format.jl
+++ b/src/Format.jl
@@ -163,7 +163,7 @@ The iterator returns a 3-tuple of `str`, `id`, and `style` where
   * `style` is the `Style` applied to the token.
 
 """
-immutable TokenIterator
+struct TokenIterator
     ctx::Context
     theme::Theme
 end

--- a/src/Highlights.jl
+++ b/src/Highlights.jl
@@ -14,25 +14,21 @@ module Highlights
 using Compat, DocStringExtensions
 const Str = all(s -> isdefined(Core, s), (:String, :AbstractString)) ? String : UTF8String
 
-if VERSION < v"0.6.0-dev.1254"
-    takebuf_str(b) = takebuf_string(b)
-else
-    takebuf_str(b) = String(take!(b))
-end
+takebuf_str(b) = String(take!(b))
 
 """
 $(TYPEDEF)
 
 Represents a source code lexer used to tokenise text.
 """
-abstract AbstractLexer
+abstract type AbstractLexer end
 
 """
 $(TYPEDEF)
 
 Represents a colour scheme used to highlight tokenised source code.
 """
-abstract AbstractTheme
+abstract type AbstractTheme end
 
 # Submodules.
 
@@ -82,25 +78,25 @@ output to `io` in the given format `mime`. `theme` defaults to `Themes.DefaultTh
 ```jldoctest
 julia> using Highlights
 
-julia> highlight(STDOUT, MIME("text/html"), "2x", Lexers.JuliaLexer)
+julia> highlight(stdout, MIME("text/html"), "2x", Lexers.JuliaLexer)
 <pre class='hljl'>
 <span class='hljl-ni'>2</span><span class='hljl-n'>x</span>
 </pre>
 
-julia> highlight(STDOUT, MIME("text/latex"), "'x'", Lexers.JuliaLexer, Themes.VimTheme)
+julia> highlight(stdout, MIME("text/latex"), "'x'", Lexers.JuliaLexer, Themes.VimTheme)
 \\begin{lstlisting}
 (*@\\HLJLsc{{\\textquotesingle}x{\\textquotesingle}}@*)
 \\end{lstlisting}
 
 ```
 """
-function highlight{
-        L <: AbstractLexer,
-        T <: AbstractTheme,
-    }(
+function highlight(
         io::IO, mime::MIME, src::AbstractString,
         lexer::Type{L}, theme::Type{T} = Themes.DefaultTheme,
-    )
+    ) where {
+        L <: AbstractLexer,
+  T <: AbstractTheme,
+}
     Format.render(io, mime, Compiler.lex(src, L), Themes.theme(T))
 end
 
@@ -128,7 +124,7 @@ julia> stylesheet(buf, MIME("text/css"), Themes.EmacsTheme)
 
 ```
 """
-stylesheet{T <: AbstractTheme}(io::IO, mime::MIME, theme::Type{T} = Themes.DefaultTheme) =
+stylesheet(io::IO, mime::MIME, theme::Type{T} = Themes.DefaultTheme) where {T <: AbstractTheme} =
     Format.render(io, mime, Themes.theme(T))
 
 end # module

--- a/src/Lexers.jl
+++ b/src/Lexers.jl
@@ -27,7 +27,7 @@ block.
 ```jldoctest
 julia> using Highlights.Lexers
 
-julia> abstract CustomLexer <: AbstractLexer
+julia> abstract type CustomLexer <: AbstractLexer end
 
 julia> @lexer CustomLexer Dict(
            :name => "Custom",
@@ -95,17 +95,17 @@ export
     TOMLLexer
 
 "A FORTRAN 90 source code lexer."
-abstract FortranLexer <: AbstractLexer
+abstract type FortranLexer <: AbstractLexer end
 "A lexer for Julia source code."
-abstract JuliaLexer <: AbstractLexer
+abstract type JuliaLexer <: AbstractLexer end
 "A lexer for Julia REPL sessions."
-abstract JuliaConsoleLexer <: AbstractLexer
+abstract type JuliaConsoleLexer <: AbstractLexer end
 "A lexer for MATLAB source code."
-abstract MatlabLexer <: AbstractLexer
+abstract type MatlabLexer <: AbstractLexer end
 "A lexer for the R language."
-abstract RLexer <: AbstractLexer
+abstract type RLexer <: AbstractLexer end
 "TOML (Tom's Obvious, Minimal Language) lexer."
-abstract TOMLLexer <: AbstractLexer
+abstract type TOMLLexer <: AbstractLexer end
 
 
 # Definitions.

--- a/src/Themes.jl
+++ b/src/Themes.jl
@@ -21,7 +21,7 @@ $(TYPEDEF)
 
 Represents a single RGB colour value that can be 'active' or 'inactive'.
 """
-immutable RGB
+struct RGB
     r::UInt8
     g::UInt8
     b::UInt8
@@ -63,7 +63,7 @@ $(TYPEDEF)
 An internal type used to track colour scheme definition information such as foreground and
 background colours as well as bold, italic, and underlining.
 """
-immutable Style
+struct Style
     fg::RGB
     bg::RGB
     bold::Bool
@@ -100,7 +100,7 @@ $(TYPEDEF)
 
 Represents a "compiled" colour scheme.
 """
-immutable Theme
+struct Theme
     base::Style
     styles::Vector{Style}
     Theme(base::Style, n::Integer) = new(base, Vector{Style}(n))
@@ -135,7 +135,7 @@ must be a subtype of `AbstractTheme`.
 ```jldoctest
 julia> using Highlights.Themes
 
-julia> abstract CustomTheme <: AbstractTheme
+julia> abstract type CustomTheme <: AbstractTheme end
 
 julia> @theme CustomTheme Dict(
            :name => "Custom",
@@ -172,26 +172,26 @@ export
     XcodeTheme
 
 "The default colour scheme with colours based on the Julia logo."
-abstract DefaultTheme <: AbstractTheme
+abstract type DefaultTheme <: AbstractTheme end
 
 "A theme based on the Emacs colour scheme."
-abstract EmacsTheme <: AbstractTheme
+abstract type EmacsTheme <: AbstractTheme end
 "A GitHub inspired colour scheme."
-abstract GitHubTheme <: AbstractTheme
+abstract type GitHubTheme <: AbstractTheme end
 "A colour scheme similar to the Monokai theme."
-abstract MonokaiTheme <: AbstractTheme
+abstract type MonokaiTheme <: AbstractTheme end
 "Based on the default colour scheme used by the Pygments highlighter."
-abstract PygmentsTheme <: AbstractTheme
+abstract type PygmentsTheme <: AbstractTheme end
 "A Tango-inspired colour scheme."
-abstract TangoTheme <: AbstractTheme
+abstract type TangoTheme <: AbstractTheme end
 "Based on the default trac highlighter."
-abstract TracTheme <: AbstractTheme
+abstract type TracTheme <: AbstractTheme end
 "A Vim 7.0 based colour scheme."
-abstract VimTheme <: AbstractTheme
+abstract type VimTheme <: AbstractTheme end
 "A theme based on the default Visual Studio colours."
-abstract VisualStudioTheme <: AbstractTheme
+abstract type VisualStudioTheme <: AbstractTheme end
 "A theme based on the default Xcode colour scheme."
-abstract XcodeTheme <: AbstractTheme
+abstract type XcodeTheme <: AbstractTheme end
 
 
 # Theme definitions.

--- a/src/Tokens.jl
+++ b/src/Tokens.jl
@@ -101,7 +101,7 @@ const __TOKENS__ = [
 const __INDICES__ = Dict([(s, n) for (n, s) in enumerate(__TOKENS__)])
 const __FALLBACKS__ = zeros(Int, length(__TOKENS__))
 
-immutable TokenValue
+struct TokenValue
     value::Int
 end
 TokenValue(s::Symbol) = TokenValue(__INDICES__[s])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,6 @@
 using Highlights, Compat
 
-if VERSION >= v"0.5.0-dev+7720"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 
 #
@@ -44,14 +39,14 @@ end
 using Highlights.Tokens, Highlights.Themes, Highlights.Lexers
 
 # Error reporting for broken lexers.
-abstract BrokenLexer <: Highlights.AbstractLexer
+abstract type BrokenLexer <: Highlights.AbstractLexer end
 @lexer BrokenLexer Dict(
     :tokens => Dict(:root => [(r"\w+", TEXT, (:b, :a))], :a => [], :b => []),
 )
 
 # Lexer inheritance.
-abstract ParentLexer <: Highlights.AbstractLexer
-abstract ChildLexer <: ParentLexer
+abstract type ParentLexer <: Highlights.AbstractLexer end
+abstract type ChildLexer <: ParentLexer end
 @lexer ParentLexer Dict(
     :tokens => Dict(:root => [(r"#.*$"m, COMMENT)])
 )
@@ -59,7 +54,7 @@ abstract ChildLexer <: ParentLexer
     :tokens => Dict(:root => [:__inherit__, (r"\d+", NUMBER), (r".", TEXT)])
 )
 
-abstract NumberLexer <: Highlights.AbstractLexer
+abstract type NumberLexer <: Highlights.AbstractLexer end
 @lexer NumberLexer Dict(
     :tokens => Dict(
         :root => [
@@ -73,7 +68,7 @@ abstract NumberLexer <: Highlights.AbstractLexer
     ),
 )
 
-abstract SelfLexer <: Highlights.AbstractLexer
+abstract type SelfLexer <: Highlights.AbstractLexer end
 @lexer SelfLexer Dict(
     :tokens => Dict(
         :root => [
@@ -94,13 +89,13 @@ abstract SelfLexer <: Highlights.AbstractLexer
 
 # Custom output format. A DOM-like node "buffer".
 
-immutable Node
+struct Node
     name::Symbol
     text::Highlights.Str
     class::Highlights.Str
 end
 
-immutable NodeBuffer <: IO
+struct NodeBuffer <: IO
     nodes::Vector{Node}
 end
 


### PR DESCRIPTION
Ran FemtoCleaner manually and dropped 0.4/5 references from the docs and the CI.

It looks like the tests don't pass on 0.6 though.. related to some syntax updates perhaps? @mpastell, would you perhaps be willing to take a look?

Should fix #14 in the end.