### PR TITLE
Fix LaTeX escaping in text nodes and add unicode conversion

### DIFF
--- a/src/Format.jl
+++ b/src/Format.jl
@@ -237,7 +237,7 @@ function escape(io::IO, ::MIME"text/latex", str::AbstractString; charescape=fals
         char === '}'   ? printe(io, charescape, "{\\}}") :
         char === '~'   ? printe(io, charescape, "{\\textasciitilde}") :
         char === '"'   ? printe(io, charescape, "\"{}") :
-        # Linebreaks within an escapeinside don't occour if not replaced by proper
+        # Linebreaks within an escapeinside do not occur if not replaced by proper
         # LaTeX linebreaks. Also to preserve spaces outside of verbatim they need to
         # be explicity placed inside an mbox (or hphantom).
         (char === '\n' && !charescape) ? printe(io, charescape, "{\\newline}") :

--- a/src/Format.jl
+++ b/src/Format.jl
@@ -203,7 +203,7 @@ function render(io::IO, mime::MIME"text/latex", tokens::TokenIterator)
     println(io, "\\begin{lstlisting}")
     for (str, id, style) in tokens
         id === :t || print(io, "(*@\\HLJL", id, "{")
-        escape(io, mime, str)
+        escape(io, mime, str; charescape=(id === :t))
         id === :t || print(io, "}@*)")
     end
     println(io, "\n\\end{lstlisting}")
@@ -223,22 +223,28 @@ function escape(io::IO, ::MIME"text/html", str::AbstractString)
     end
 end
 
-function escape(io::IO, ::MIME"text/latex", str::AbstractString)
+function escape(io::IO, ::MIME"text/latex", str::AbstractString; charescape=false)
     for char in str
-        char === '`'  ? print(io, "{\\textasciigrave}") :
-        char === '\'' ? print(io, "{\\textquotesingle}") :
-        char === '$'  ? print(io, "{\\\$}") :
-        char === '%'  ? print(io, "{\\%}") :
-        char === '#'  ? print(io, "{\\#}") :
-        char === '&'  ? print(io, "{\\&}") :
-        char === '\\' ? print(io, "{\\textbackslash}") :
-        char === '^'  ? print(io, "{\\textasciicircum}") :
-        char === '_'  ? print(io, "{\\_}") :
-        char === '{'  ? print(io, "{\\{}") :
-        char === '}'  ? print(io, "{\\}}") :
-        char === '~'  ? print(io, "{\\textasciitilde}") :
+        char === '`'  ? printe(io, charescape, "{\\textasciigrave}") :
+        char === '\'' ? printe(io, charescape, "{\\textquotesingle}") :
+        char === '$'  ? printe(io, charescape, "{\\\$}") :
+        char === '%'  ? printe(io, charescape, "{\\%}") :
+        char === '#'  ? printe(io, charescape, "{\\#}") :
+        char === '&'  ? printe(io, charescape, "{\\&}") :
+        char === '\\' ? printe(io, charescape, "{\\textbackslash}") :
+        char === '^'  ? printe(io, charescape, "{\\textasciicircum}") :
+        char === '_'  ? printe(io, charescape, "{\\_}") :
+        char === '{'  ? printe(io, charescape, "{\\{}") :
+        char === '}'  ? printe(io, charescape, "{\\}}") :
+        char === '~'  ? printe(io, charescape, "{\\textasciitilde}") :
             print(io, char)
     end
+end
+
+function printe(io::IO, charescape::Bool, s)
+    charescape && print(io, "(*@{")
+    print(io, s)
+    charescape && print(io, "}@*)")
 end
 
 end # module

--- a/src/Format.jl
+++ b/src/Format.jl
@@ -225,18 +225,19 @@ end
 
 function escape(io::IO, ::MIME"text/latex", str::AbstractString; charescape=false)
     for char in str
-        char === '`'  ? printe(io, charescape, "{\\textasciigrave}") :
-        char === '\'' ? printe(io, charescape, "{\\textquotesingle}") :
-        char === '$'  ? printe(io, charescape, "{\\\$}") :
-        char === '%'  ? printe(io, charescape, "{\\%}") :
-        char === '#'  ? printe(io, charescape, "{\\#}") :
-        char === '&'  ? printe(io, charescape, "{\\&}") :
-        char === '\\' ? printe(io, charescape, "{\\textbackslash}") :
-        char === '^'  ? printe(io, charescape, "{\\textasciicircum}") :
-        char === '_'  ? printe(io, charescape, "{\\_}") :
-        char === '{'  ? printe(io, charescape, "{\\{}") :
-        char === '}'  ? printe(io, charescape, "{\\}}") :
-        char === '~'  ? printe(io, charescape, "{\\textasciitilde}") :
+        char === '`'   ? printe(io, charescape, "{\\textasciigrave}") :
+        char === '\''  ? printe(io, charescape, "{\\textquotesingle}") :
+        char === '$'   ? printe(io, charescape, "{\\\$}") :
+        char === '%'   ? printe(io, charescape, "{\\%}") :
+        char === '#'   ? printe(io, charescape, "{\\#}") :
+        char === '&'   ? printe(io, charescape, "{\\&}") :
+        char === '\\'  ? printe(io, charescape, "{\\textbackslash}") :
+        char === '^'   ? printe(io, charescape, "{\\textasciicircum}") :
+        char === '_'   ? printe(io, charescape, "{\\_}") :
+        char === '{'   ? printe(io, charescape, "{\\{}") :
+        char === '}'   ? printe(io, charescape, "{\\}}") :
+        char === '~'   ? printe(io, charescape, "{\\textasciitilde}") :
+        char === '"'   ? printe(io, charescape, "\"{}") :
             print(io, char)
     end
 end

--- a/src/Format.jl
+++ b/src/Format.jl
@@ -128,6 +128,7 @@ function render(io::IO, mime::MIME"text/latex", theme::Theme)
             basicstyle=\\ttfamily\\footnotesize,
             upquote=true,
             breaklines=true,
+            breakindent=0pt,
             keepspaces=true,
             showspaces=false,
             columns=fullflexible,
@@ -236,6 +237,11 @@ function escape(io::IO, ::MIME"text/latex", str::AbstractString; charescape=fals
         char === '}'   ? printe(io, charescape, "{\\}}") :
         char === '~'   ? printe(io, charescape, "{\\textasciitilde}") :
         char === '"'   ? printe(io, charescape, "\"{}") :
+        # Linebreaks within an escapeinside don't occour if not replaced by proper
+        # LaTeX linebreaks. Also to preserve spaces outside of verbatim they need to
+        # be explicity placed inside an mbox (or hphantom).
+        (char === '\n' && !charescape) ? printe(io, charescape, "{\\newline}") :
+        (char === ' ' && !charescape) ? printe(io, charescape, "{\\mbox{\\space}}") :
             print(io, char)
     end
 end

--- a/src/Format.jl
+++ b/src/Format.jl
@@ -119,8 +119,6 @@ function render(io::IO, ::MIME"text/html", theme::Theme)
 end
 
 function render(io::IO, mime::MIME"text/latex", theme::Theme)
-    println(io, "\\usepackage[T1]{fontenc}")
-    println(io, "\\usepackage{textcomp}")
     println(io, "\\usepackage{upquote}")
     println(io, "\\usepackage{listings}")
     println(io, "\\usepackage{xcolor}")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,12 +261,35 @@ end
             end
         end
         @testset "LaTeX" begin
+            escape = function(mime,str;charescape=false)
+                buffer = IOBuffer()
+                Highlights.Format.escape(buffer,mime,str,charescape=charescape)
+                return Highlights.takebuf_str(buffer)
+            end
+            escapeinside(str) = "(*@{"*str*"}@*)"
             let mime = MIME("text/latex")
                 @test render(mime, Themes.Style("fg: 111"))   == "[1]{\\textcolor[RGB]{17,17,17}{#1}}"
                 @test render(mime, Themes.Style("bg: 111"))   == "[1]{\\colorbox[RGB]{17,17,17}{#1}}"
                 @test render(mime, Themes.Style("bold"))      == "[1]{\\textbf{#1}}"
                 @test render(mime, Themes.Style("italic"))    == "[1]{\\textit{#1}}"
                 @test render(mime, Themes.Style("underline")) == "[1]{\\underline{#1}}"
+                mime = MIME("text/latex")
+                ebrace_L = escape(mime,"{")
+                ebrace_R = escape(mime,"}")
+                # This is placed in a verbatim env. so there must be an additional charescape
+                @test escape(mime,"{}",charescape=true) == escapeinside(ebrace_L)*escapeinside(ebrace_R)
+                # This is already escaped so now charescape
+                @test escape(mime,"{}",charescape=false) == ebrace_L*ebrace_R
+                # This is placed in a verbatim so whitespace is already handled by the verbatim env.
+                # Only special characters need to be escaped
+                @test escape(mime,"   some text\n next line{}",charescape=true) ==
+                    "   some text\n next line"*escapeinside(ebrace_L)*escapeinside(ebrace_R)
+                # This is escaped so LaTeX automatically removes whitespace characters.
+                # Also no additional escapeinside for special characters needed.
+                n = escape(mime,"\n",charescape=false)
+                s = escape(mime," ",charescape=false)
+                @test escape(mime,"   some text\n next line{}",charescape=false) ==
+                    "$(s)$(s)$(s)some$(s)text$(n)$(s)next$(s)line"*ebrace_L*ebrace_R
             end
         end
         @testset "Custom Nodes" begin


### PR DESCRIPTION
Continuation of #29.
- Fix #28 
- Add unicode to latex conversion