### PR TITLE
Fix repl_splitter for first char in newline being non-ascii

### DIFF
--- a/src/lexers/julia.jl
+++ b/src/lexers/julia.jl
@@ -197,7 +197,7 @@ function julia_repl_splitter(ctx::Context)
         end
     end
     @label FINISHED
-    return ctx.pos[]:prevind(s, i - 1)
+    return ctx.pos[]:prevind(s, i, 2)
 end
 
 @lexer JuliaConsoleLexer Dict(

--- a/test/lexers/jlcon.jl
+++ b/test/lexers/jlcon.jl
@@ -140,3 +140,15 @@ tokentest(
     NAME => "b",
     TEXT => "\n7\n",
 )
+
+tokentest(
+    Lexers.JuliaConsoleLexer,
+    """
+    julia> @show β
+    β = 10""",
+    NUMBER => "julia> ",
+    NAME_DECORATOR => "@show",
+    TEXT => " ",
+    NAME => "β",
+    TEXT => "\nβ = 10",
+)


### PR DESCRIPTION
Fixes `StringIndexError` in consolelexer when the first character after a linebreak is a non-ascii character.

In the original code `prevind(s, i - 1)`, `i-1` had no effect for non-ascii characters because `i-1` gives an invalid index that is still within the character. 
```
julia> prevind("abβc",5)
3

julia> prevind("abβc",5-1)
3
```
So to go back 2 indices this must be replaced with `prevind(s, i, 2)`.