### PR TITLE
Fixes for Julia v1.12+

### DIFF
--- a/src/lexers/julia.jl
+++ b/src/lexers/julia.jl
@@ -66,9 +66,8 @@ end
 julia_is_triple_string_macro(ctx::Context) = julia_is_string_macro(ctx, 3)
 
 # Julia Script Lexer.
-
 @lexer JuliaLexer let
-    keywords = [kw.keyword for kw in REPL.REPLCompletions.complete_keyword("")]
+    keywords = [kw.keyword for kw in REPL.REPLCompletions.sorted_keywords]
     char_regex = [
         raw"'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,3}|",
         raw"\\u[a-fA-F0-9]{1,4}|\\U[a-fA-F0-9]{1,6}|",

--- a/src/lexers/julia.jl
+++ b/src/lexers/julia.jl
@@ -67,7 +67,7 @@ julia_is_triple_string_macro(ctx::Context) = julia_is_string_macro(ctx, 3)
 
 # Julia Script Lexer.
 @lexer JuliaLexer let
-    keywords = [kw.keyword for kw in REPL.REPLCompletions.sorted_keywords]
+    keywords = copy(REPL.REPLCompletions.sorted_keywords)
     char_regex = [
         raw"'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,3}|",
         raw"\\u[a-fA-F0-9]{1,4}|\\U[a-fA-F0-9]{1,6}|",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -337,5 +337,5 @@ end
 # Hack to make the test in External actually usable...
 using Pkg
 Pkg.activate(joinpath(@__DIR__, "External"))
-Pkg.develop("Highlights")
+Pkg.develop(Pkg.PackageSpec(;path=dirname(@__DIR__)))
 using External


### PR DESCRIPTION
REPL.REPLCompletions had some internals change around recently, this adds a polyfill for the completions.  I ran into this because `Debugger.jl` refused to precompile on Julia v1.12 because of this.