### PR TITLE
ci(gogh): set git identity for artifacts branch commit

### DIFF
--- a/.github/workflows/update-gogh.yml
+++ b/.github/workflows/update-gogh.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           version: '1'
 
+      - run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - run: julia --project=scripts/gogh -e 'using Pkg; Pkg.instantiate()'
 
       - run: julia --project=scripts/gogh scripts/gogh/gogh.jl artifacts


### PR DESCRIPTION
The update script commits to the artifacts branch, but the CI runner has no git identity configured. Without it, `git commit` fails with "empty ident name not allowed".

See https://github.com/JuliaDocs/Highlights.jl/actions/runs/23715278313