### PR TITLE
feat: highlight embedded languages via injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Language injection via the `inject` keyword on `highlight`. With
+  `inject=true`, code embedded in the source is highlighted by its own grammar
+  (JavaScript and CSS in HTML, command literals in Julia). Default output is
+  unchanged and loads no embedded grammars [#88].
 - Elixir syntax highlighting, covered by reference tests across ANSI, HTML,
   LaTeX, and Typst output [#86].
 
 ### Fixed
 
+- Colour the capture names markup and CSS grammars emit that previously fell
+  through to the plain foreground: `tag` and `tag.error` for HTML tag names,
+  `property` for CSS property names and selectors [#88].
 - Stop capture styling from bleeding onto the whitespace and newlines between
   tokens. Node-level grammar captures (e.g. a whole Fortran statement matched as
   a keyword) no longer style trailing spaces or line breaks; string and comment

--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ tree_sitter_bash_jll = "7332bcdc-bd2a-5999-b4fe-680b85f40771"
 tree_sitter_elixir_jll = "1780c887-7120-5810-92a7-28bfca871107"
 tree_sitter_fortran_jll = "f370be48-5072-5a80-a2be-a91280f1992d"
 tree_sitter_go_jll = "beecb120-e197-59fa-b79c-0316d51c9920"
+tree_sitter_html_jll = "3890dd07-cc9a-5220-ba41-7d914d0b28d4"
 tree_sitter_javascript_jll = "ca45b743-11fc-5578-b74a-7528860c0bda"
 tree_sitter_julia_jll = "52be201e-a5e9-5cfe-8bf2-2dc4b062171c"
 tree_sitter_matlab_jll = "67499a12-87ae-5367-9f08-9b6e5d7d8b47"
@@ -33,4 +34,4 @@ tree_sitter_rust_jll = "b2197e8e-fe20-5781-846b-d7979e3cddf2"
 tree_sitter_toml_jll = "a1529afc-395a-556b-957c-713caec82e13"
 
 [targets]
-test = ["ReferenceTests", "Test", "Typst_jll", "tectonic_jll", "tree_sitter_bash_jll", "tree_sitter_elixir_jll", "tree_sitter_fortran_jll", "tree_sitter_go_jll", "tree_sitter_javascript_jll", "tree_sitter_julia_jll", "tree_sitter_matlab_jll", "tree_sitter_python_jll", "tree_sitter_r_jll", "tree_sitter_rust_jll", "tree_sitter_toml_jll"]
+test = ["ReferenceTests", "Test", "Typst_jll", "tectonic_jll", "tree_sitter_bash_jll", "tree_sitter_elixir_jll", "tree_sitter_fortran_jll", "tree_sitter_go_jll", "tree_sitter_html_jll", "tree_sitter_javascript_jll", "tree_sitter_julia_jll", "tree_sitter_matlab_jll", "tree_sitter_python_jll", "tree_sitter_r_jll", "tree_sitter_rust_jll", "tree_sitter_toml_jll"]

--- a/src/api.jl
+++ b/src/api.jl
@@ -103,6 +103,7 @@ function highlight(
     preprocess = nothing,
     stylesheet::Bool = false,
     classprefix::AbstractString = "hl",
+    inject::Bool = false,
 )
     highlight(
         MIME("text/ansi"),
@@ -113,6 +114,7 @@ function highlight(
         preprocess,
         stylesheet,
         classprefix,
+        inject,
     )
 end
 
@@ -125,6 +127,7 @@ function highlight(
     preprocess = nothing,
     stylesheet::Bool = false,
     classprefix::AbstractString = "hl",
+    inject::Bool = false,
 )
     io = IOBuffer()
     highlight(
@@ -137,6 +140,7 @@ function highlight(
         preprocess,
         stylesheet,
         classprefix,
+        inject,
     )
     return String(take!(io))
 end
@@ -151,6 +155,7 @@ function highlight(
     preprocess = nothing,
     stylesheet::Bool = false,
     classprefix::AbstractString = "hl",
+    inject::Bool = false,
 )
     highlight(
         io,
@@ -162,6 +167,7 @@ function highlight(
         preprocess,
         stylesheet,
         classprefix,
+        inject,
     )
 end
 
@@ -186,6 +192,7 @@ function highlight(
     preprocess = nothing,
     stylesheet::Bool = false,
     classprefix::AbstractString = "hl",
+    inject::Bool = false,
 )
     lang_sym = normalize_language(language)
 
@@ -198,8 +205,7 @@ function highlight(
         # Normal path - highlight entire source
         lang_module = resolve_language(language)
         parser = TreeSitter.Parser(lang_module)
-        query = TreeSitter.Query(lang_module, ["highlights"])
-        tokens = highlight_tokens(parser, query, source)
+        tokens = highlight_tokens(parser, source; inject)
         format(
             io,
             mime,
@@ -219,8 +225,7 @@ function highlight(
             if segment isa CodeSegment
                 lang_module = resolve_language(segment.language)
                 parser = TreeSitter.Parser(lang_module)
-                query = TreeSitter.Query(lang_module, ["highlights"])
-                tokens = highlight_tokens(parser, query, segment.text)
+                tokens = highlight_tokens(parser, segment.text; inject)
                 format(
                     io,
                     mime,

--- a/src/highlight.jl
+++ b/src/highlight.jl
@@ -52,7 +52,7 @@ function default_capture_colors()
         "variable" => 8,
         "variable.builtin" => 14,
         "variable.parameter" => 8,
-        "property" => 8,
+        "property" => 7,
 
         # Constants
         "constant" => 4,
@@ -68,6 +68,10 @@ function default_capture_colors()
 
         # Comments
         "comment" => 1,
+
+        # Markup
+        "tag" => 2,
+        "tag.error" => 10,
 
         # Operators/punctuation
         "operator" => 8,
@@ -327,22 +331,34 @@ function trim_capture(text::AbstractString, byte_range::Tuple{Int,Int})
 end
 
 """
-    highlight_tokens(parser::TreeSitter.Parser, query::TreeSitter.Query, source::AbstractString;
-                     priorities::Dict=default_capture_priorities()) -> Vector{HighlightToken}
+    highlight_tokens(parser::TreeSitter.Parser, source::AbstractString;
+                     priorities::Dict=default_capture_priorities(), inject::Bool=false) -> Vector{HighlightToken}
 
 Extract highlight tokens from source code, sorted by position.
+
+With `inject=true`, languages embedded in `source` are highlighted by their own grammar:
+each injection layer is highlighted with its own `highlights` query, and overlap between a
+coarse enclosing capture and a fine embedded one resolves in `deduplicate_tokens`, where the
+shorter span wins. With `inject=false` (default) only the top-level grammar highlights, and
+no embedded grammars are loaded.
 """
 function highlight_tokens(
     parser::TreeSitter.Parser,
-    query::TreeSitter.Query,
     source::AbstractString;
     priorities::Dict = default_capture_priorities(),
+    inject::Bool = false,
 )
     tokens = HighlightToken[]
-    tree = Base.parse(parser, source)
+    # max_depth=0 leaves the tree a single layer, so injected grammars are neither resolved
+    # nor loaded when injection is off.
+    tree = Base.parse(parser, source; max_depth = inject ? 8 : 0)
+    layers = inject ? TreeSitter.layers(tree) : (tree,)
 
-    for m in eachmatch(query, tree)
-        if TreeSitter.predicate(query, m, source)
+    for layer in layers
+        haskey(layer.language.queries, "highlights") || continue
+        query = TreeSitter.Query(layer.language, ["highlights"])
+        for m in eachmatch(query, layer)
+            TreeSitter.predicate(query, m, source) || continue
             for c in TreeSitter.captures(m)
                 capture_name = TreeSitter.capture_name(query, c)
                 text = TreeSitter.slice(source, c.node)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,6 +238,70 @@ read_sample(name) = read(joinpath(SAMPLES_DIR, name), String)
 
         # Unknown defaults to 8
         @test Highlights.get_capture_color("unknown.capture", colors) == 8
+
+        # Markup tag names and CSS property names are distinct from the default foreground
+        @test Highlights.get_capture_color("tag", colors) != 8
+        @test Highlights.get_capture_color("property", colors) != 8
+        @test Highlights.get_capture_color("tag.error", colors) ==
+              Highlights.get_capture_color("error", colors)
+    end
+
+    @testset "Markup highlighting" begin
+        theme = Highlights.load_theme("Dracula")
+        tags = Highlights.highlight(MIME("text/html"), "<b id=\"x\">hi</b>", :html, theme)
+
+        # Tag names carry the keyword colour, not the theme's plain foreground.
+        @test occursin("<span style=\"color: $(theme.colors[2])\">b</span>", tags)
+        @test !occursin("<span style=\"color: $(theme.colors[8])\">b</span>", tags)
+    end
+
+    @testset "Language injection" begin
+        theme = Highlights.load_theme("Dracula")
+        plain(source, lang) =
+            Highlights.highlight(MIME("text/plain"), source, lang, theme; inject = true)
+
+        @testset "embedded code uses the embedded language's grammar" begin
+            out = plain("<script>const x = 1;</script>", :html)
+
+            # `const` is a keyword to javascript and raw text to html.
+            @test occursin("[keyword:const]", out)
+            @test occursin("[number:1]", out)
+
+            # The enclosing html is still highlighted by html.
+            @test occursin("[tag:script]", out)
+        end
+
+        @testset "injection is off by default" begin
+            # Without inject=true the embedded javascript stays raw text.
+            out = Highlights.highlight(
+                MIME("text/plain"),
+                "<script>const x = 1;</script>",
+                :html,
+                theme,
+            )
+            @test !occursin("[keyword:const]", out)
+            @test occursin("const x = 1;", out)
+            @test occursin("[tag:script]", out)
+        end
+
+        @testset "a grammar without injectable content is unchanged" begin
+            out = plain("f(x) = x\n", :julia)
+            @test occursin("[function.call:f]", out)
+        end
+
+        @testset "an unavailable grammar degrades to unhighlighted text" begin
+            # No tree_sitter_css_jll exists, so html's css injection cannot resolve.
+            out = plain("<style>a { color: red; }</style>", :html)
+
+            @test occursin("[tag:style]", out)
+            @test occursin("a { color: red; }", out)   # present, just unstyled
+        end
+
+        @testset "source text is preserved verbatim" begin
+            source = "<script>const x = 1;</script>\n"
+            out = plain(source, :html)
+            @test replace(out, r"\[[a-z.]+:" => "", "]" => "") == source
+        end
     end
 
     @testset "Capture style mapping" begin


### PR DESCRIPTION
Add an opt-in `inject` keyword to `highlight`. With `inject=true`, code embedded in the source is highlighted by its own grammar: the JavaScript and CSS inside an HTML document, command literals in Julia. Each injection layer is highlighted with its own queries, and the tokens merge into one stream where the shorter span wins on overlap. Default output is byte-identical and loads no embedded grammars, so existing callers are unaffected.

Colour the capture names markup and CSS grammars emit that previously fell through to the plain foreground and rendered as unstyled text: `tag` and `tag.error` for HTML tag names, `property` for CSS property names and selectors. Colouring `property` also colours object member access in languages that capture it.

---

Depends on MichaelHatherly/TreeSitter.jl#60, which adds the layered `parse` this builds on. CI here stays red until that merges and a TreeSitter release ships the injection API; the `TreeSitter` compat bound then needs bumping to that version.